### PR TITLE
Made ResponsiveTable component SSR friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-next-responsive-table",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Responsive read-only table <-> expandable list for material-ui 1.0-beta.",
   "main": "lib/index.js",
   "files": [

--- a/src/ResponsiveTable.js
+++ b/src/ResponsiveTable.js
@@ -28,6 +28,7 @@ class ResponsiveTable extends Component {
       page,
       rowsPerPage,
       showPagination,
+      implementation,
       ExpansionPanelDetailsProps,
       ExpansionPanelDetailsTypographyProps,
       ExpansionPanelMoreIconProps,
@@ -48,7 +49,7 @@ class ResponsiveTable extends Component {
       <div className={classes.root}>
         {/* DESKTOP BIG TABLE */}
 
-        <Hidden only={tableBreakpoints || ['xs', 'sm', 'md']}>
+        <Hidden only={tableBreakpoints || ['xs', 'sm', 'md']} implementation={implementation || 'js'}>
           <DataTable
             columns={columns}
             count={count}
@@ -71,7 +72,7 @@ class ResponsiveTable extends Component {
 
         {/* MOBILE EXPANDABLE LIST OF CARDS */}
 
-        <Hidden only={listBreakpoints || ['lg', 'xl']}>
+        <Hidden only={listBreakpoints || ['lg', 'xl']} implementation={implementation || 'js'}>
           <DataList
             columns={columns}
             count={count}


### PR DESCRIPTION
This PR is to resolve #2 

Now, we can pass an `implementation` prop to the `ResponsiveTable` component in order to apply the implementation to the underlying `<Hidden>` component